### PR TITLE
Improve DOCX mapping fidelity and newline rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ This repository contains the Razor views that power MAS ERP's document managemen
 ### DOCX Handling Strategy
 The `DocxToJsonConverter2` class demonstrates how we preserve the fidelity of Word documents:
 - **Structure traversal** – opens `.docx` files through the Open XML SDK, inspects paragraphs, tables, and hyperlinks, and serializes each element with unique IDs so the front-end can render and edit them predictably.
+- **Deterministic mapping** – attaches a `StructureKey` to each paragraph/table that encodes its hierarchical path so edited JSON targets the exact source element even across nested content controls.
 - **Formatting capture** – collects run-level formatting (bold, italics, underline, font family/size, colors, shading, highlighting) and paragraph-level settings (alignment, bidirectional layout, background fills).
+- **Line fidelity** – preserves manual line breaks, tabs, and checkbox glyphs when translating runs to JSON/HTML to keep the Word layout intact during round-trips.
 - **Table intelligence** – records table, row, and cell borders, merged cells (`GridSpan`, vertical merges with computed `rowSpan`), background fills, and paragraph direction so complex layouts survive round-trips.
 - **Interactive controls** – detects content controls for checkboxes (`SdtRun`) and maps them to structured JSON objects containing both the checked state and descriptive text.
 - **Culture awareness** – inspects document defaults to determine left-to-right vs. right-to-left direction, ensuring Arabic layouts keep their reading order when rendered on the web.
@@ -70,7 +72,9 @@ Although the current snapshot focuses on Word files, the same design can be exte
 
 ### منهجية التعامل مع ملفات Word
 - **قراءة الهيكل**: يتم فتح الملف عبر Open XML واستعراض الفقرات والجداول والارتباطات مع إعطاء كل عنصر رقمًا فريدًا.
+- **مفتاح بنيوي ثابت**: تتم إضافة خاصية `StructureKey` لكل فقرة/جدول لتمثيل مسارها داخل المستند، مما يسمح بإعادة الحقن داخل العنصر الصحيح حتى مع وجود عناصر متداخلة.
 - **حفظ التنسيق**: يتم التقاط خصائص الخطوط (غامق، مائل، مسطر، اللون، حجم الخط، اسم الخط، الخلفيات) بالإضافة إلى محاذاة الفقرات واتجاهها.
+- **الحفاظ على الأسطر**: يتم الاحتفاظ بعمليات الانتقال للسطر (`Line Breaks`) وعلامات التبويب ومربعات الاختيار أثناء التحويل بين JSON و HTML لضمان تطابق العرض مع ملف Word الأصلي.
 - **ذكاء الجداول**: تُحفظ حدود الجداول والصفوف والخلايا، وحالات الدمج، ولون الخلفية، واتجاه الكتابة داخل كل خلية.
 - **عناصر تفاعلية**: يتم اكتشاف مربعات الاختيار داخل المستند وتحويلها إلى JSON مع حالة التحديد والنص المرافق.
 - **دعم اللغات**: يتم تحديد اتجاه المستند (RTL/LTR) تلقائيًا لضمان ظهور المستندات العربية بشكل صحيح.

--- a/docapi.cshtml
+++ b/docapi.cshtml
@@ -3,7 +3,9 @@
 @using System.Data
 @using System.IO
 @using System.Linq
+@using System.Globalization
 @using System.Web
+@using System.Text
 @using System.Text.RegularExpressions
 @using Newtonsoft.Json
 @using DocumentFormat.OpenXml
@@ -61,13 +63,13 @@
         public int Version { get; set; }
     }
 
-    public class JsonParagraph { public int ID { get; set; } public string Type { get; set; } = "Paragraph"; public List<object> Content { get; set; } = new List<object>(); public Dictionary<string, object> Formatting { get; set; } = new Dictionary<string, object>(); }
+    public class JsonParagraph { public int ID { get; set; } public string Type { get; set; } = "Paragraph"; public string StructureKey { get; set; } public List<object> Content { get; set; } = new List<object>(); public Dictionary<string, object> Formatting { get; set; } = new Dictionary<string, object>(); }
     public class JsonRun { public string Text { get; set; } public Dictionary<string, bool> Formatting { get; set; } = new Dictionary<string, bool>(); public Dictionary<string, string> FormattingValues { get; set; } = new Dictionary<string, string>(); }
     public class JsonCheckbox { public string Type { get; set; } = "Checkbox"; public bool IsChecked { get; set; } public string Content { get; set; } }
-    public class JsonTable { public int ID { get; set; } public string Type { get; set; } = "Table"; public List<JsonTableRow> Content { get; set; } = new List<JsonTableRow>(); public Dictionary<string, string> Borders { get; set; } = new Dictionary<string, string>(); }
+    public class JsonTable { public int ID { get; set; } public string Type { get; set; } = "Table"; public string StructureKey { get; set; } public List<JsonTableRow> Content { get; set; } = new List<JsonTableRow>(); public Dictionary<string, string> Borders { get; set; } = new Dictionary<string, string>(); }
     public class JsonTableRow { public List<JsonTableCell> Cells { get; set; } = new List<JsonTableCell>(); public Dictionary<string, string> Borders { get; set; } = new Dictionary<string, string>(); }
     public class JsonTableCell { public string Content { get; set; } public int GridSpan { get; set; } = 1; public string VerticalMerge { get; set; } public List<JsonRun> FormattedRuns { get; set; } = new List<JsonRun>(); public List<JsonCheckbox> Checkboxes { get; set; } = new List<JsonCheckbox>(); public Dictionary<string, string> Borders { get; set; } = new Dictionary<string, string>(); public int? rowSpan { get; set; } public string Direction { get; set; } public string Alignment { get; set; } public string TextRotation { get; set; }}
-    public class JsonImage { public int ID { get; set; } public string Type { get; set; } = "Image"; public string Content { get; set; } }
+    public class JsonImage { public int ID { get; set; } public string Type { get; set; } = "Image"; public string StructureKey { get; set; } public string Content { get; set; } }
 public static readonly Regex VersionPattern = new Regex(@"^(.+?)(?:\s*\(Rev\s?(\d+)\))?$", RegexOptions.IgnoreCase);
           public static string GetVersionedPath(string basePath, int? version)
         {
@@ -227,34 +229,45 @@ public static NewDoc ConvertJsonToDocx(string jsonInput, string appPath, string 
             {
                 var body = wordDoc.MainDocumentPart.Document.Body;
 
-                var jsonElements = payload.Elements.GetEnumerator();
-                var docElements = body.Elements().ToList();
-                var docElementEnumerator = docElements.GetEnumerator();
+                var structuredElements = CollectStructuredDocElements(body);
+                var consumed = new HashSet<int>();
 
-                while (jsonElements.MoveNext())
+                foreach (var element in payload.Elements ?? new List<object>())
                 {
-                    var jObject = Newtonsoft.Json.Linq.JObject.FromObject(jsonElements.Current);
+                    var jObject = element as Newtonsoft.Json.Linq.JObject ?? Newtonsoft.Json.Linq.JObject.FromObject(element);
+                    if (jObject == null) continue;
+
                     string elementType = jObject["Type"]?.ToString();
+                    if (string.IsNullOrEmpty(elementType)) continue;
 
-                    while (docElementEnumerator.MoveNext())
+                    string structureKey = jObject["StructureKey"]?.ToString();
+                    StructuredDocElement match = null;
+
+                    if (!string.IsNullOrEmpty(structureKey))
                     {
-                        var docElement = docElementEnumerator.Current;
+                        match = structuredElements.FirstOrDefault(se => !consumed.Contains(se.Index) &&
+                                                                         se.Type == elementType &&
+                                                                         string.Equals(se.StructureKey, structureKey, StringComparison.Ordinal));
+                    }
 
-                        if (elementType == "Paragraph" && docElement is Wp.Paragraph)
-                        {
-                            var jsonPara = jObject.ToObject<JsonParagraph>();
-                            InjectTextToParagraphSafe((Wp.Paragraph)docElement, jsonPara);
-                            break; 
-                        }
-                        else if (elementType == "Table" && docElement is Wp.Table)
-                        {
-                            var jsonTable = jObject.ToObject<JsonTable>();
-                            InjectTextToTableSafe((Wp.Table)docElement, jsonTable);
-                            break;
-                        }
-                        else if (docElement is Wp.SdtBlock sdtBlock)
-                        {
-                        }
+                    if (match == null)
+                    {
+                        match = structuredElements.FirstOrDefault(se => !consumed.Contains(se.Index) && se.Type == elementType);
+                    }
+
+                    if (match == null) continue;
+
+                    consumed.Add(match.Index);
+
+                    if (elementType == "Paragraph" && match.Element is Wp.Paragraph paragraph)
+                    {
+                        var jsonPara = jObject.ToObject<JsonParagraph>();
+                        InjectTextToParagraphSafe(paragraph, jsonPara);
+                    }
+                    else if (elementType == "Table" && match.Element is Wp.Table table)
+                    {
+                        var jsonTable = jObject.ToObject<JsonTable>();
+                        InjectTextToTableSafe(table, jsonTable);
                     }
                 }
 
@@ -353,18 +366,64 @@ public static object ConvertDocxToJson(string filePath, int? version)
 }
 
 // New helper function to parse elements recursively
-private static void ParseElementsRecursive(IEnumerable<OpenXmlElement> elements, ref int elementIdCounter, MainDocumentPart mainPart, List<object> documentElements)
+private class StructuredDocElement
 {
+    public OpenXmlElement Element { get; set; }
+    public string Type { get; set; }
+    public string StructureKey { get; set; }
+    public int Index { get; set; }
+}
+
+private static List<StructuredDocElement> CollectStructuredDocElements(Wp.Body body)
+{
+    var collected = new List<StructuredDocElement>();
+    int structuralIndex = 0;
+    CollectStructuredDocElementsRecursive(body?.ChildElements, string.Empty, collected, ref structuralIndex);
+    return collected;
+}
+
+private static void CollectStructuredDocElementsRecursive(IEnumerable<OpenXmlElement> elements, string path, List<StructuredDocElement> collector, ref int structuralIndex)
+{
+    if (elements == null) return;
+    int localIndex = 0;
     foreach (var element in elements)
     {
-        elementIdCounter++;
-        if (element is Wp.Paragraph para)
+        string childPath = string.IsNullOrEmpty(path) ? localIndex.ToString() : $"{path}.{localIndex}";
+
+        if (element is Wp.Paragraph paragraph)
         {
-            documentElements.Add(ParseParagraph(para, elementIdCounter, mainPart));
+            collector.Add(new StructuredDocElement { Element = paragraph, Type = "Paragraph", StructureKey = childPath, Index = structuralIndex++ });
         }
         else if (element is Wp.Table table)
         {
-            documentElements.Add(ParseTable(table, elementIdCounter, mainPart));
+            collector.Add(new StructuredDocElement { Element = table, Type = "Table", StructureKey = childPath, Index = structuralIndex++ });
+        }
+        else if (element is Wp.SdtBlock sdtBlock)
+        {
+            CollectStructuredDocElementsRecursive(sdtBlock?.SdtContentBlock?.ChildElements, childPath, collector, ref structuralIndex);
+            localIndex++;
+            continue;
+        }
+
+        localIndex++;
+    }
+}
+
+private static void ParseElementsRecursive(IEnumerable<OpenXmlElement> elements, ref int elementIdCounter, MainDocumentPart mainPart, List<object> documentElements, string path = "")
+{
+    if (elements == null) return;
+    int index = 0;
+    foreach (var element in elements)
+    {
+        string currentKey = string.IsNullOrEmpty(path) ? index.ToString() : $"{path}.{index}";
+        elementIdCounter++;
+        if (element is Wp.Paragraph para)
+        {
+            documentElements.Add(ParseParagraph(para, elementIdCounter, mainPart, currentKey));
+        }
+        else if (element is Wp.Table table)
+        {
+            documentElements.Add(ParseTable(table, elementIdCounter, mainPart, currentKey));
         }
         else if (element is Wp.SdtBlock sdtBlock)
         {
@@ -372,14 +431,17 @@ private static void ParseElementsRecursive(IEnumerable<OpenXmlElement> elements,
             var content = sdtBlock.SdtContentBlock;
             if (content != null)
             {
-                ParseElementsRecursive(content.ChildElements, ref elementIdCounter, mainPart, documentElements);
+                ParseElementsRecursive(content.ChildElements, ref elementIdCounter, mainPart, documentElements, currentKey);
+                index++;
+                continue;
             }
         }
         else if (element.Descendants<Wp.Drawing>().Any())
         {
-            documentElements.AddRange(ParseImages(element, elementIdCounter, mainPart));
+            documentElements.AddRange(ParseImages(element, elementIdCounter, mainPart, currentKey));
         }
         // Other elements are ignored to keep the JSON clean
+        index++;
     }
 }
 
@@ -777,9 +839,60 @@ private static void InjectTextToTableSafe(Wp.Table table, JsonTable jsonTable)
     
     return "left";
 }
-private static JsonParagraph ParseParagraph(Wp.Paragraph para, int elementId, MainDocumentPart mainPart)
+private static string ExtractRunTextWithBreaks(Wp.Run run)
 {
-    var jsonPara = new JsonParagraph { ID = elementId };
+    if (run == null) return string.Empty;
+
+    var builder = new StringBuilder();
+    foreach (var child in run.ChildElements)
+    {
+        switch (child)
+        {
+            case Wp.Text text:
+                builder.Append(text.Text);
+                break;
+            case Wp.TabChar _:
+                builder.Append('\t');
+                break;
+            case Wp.Break _:
+            case Wp.CarriageReturn _:
+                builder.Append('\n');
+                break;
+            case Wp.SymbolChar symbol:
+                var value = symbol.Char?.Value;
+                if (!string.IsNullOrEmpty(value))
+                {
+                    if (int.TryParse(value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out int codePoint))
+                    {
+                        builder.Append(char.ConvertFromUtf32(codePoint));
+                    }
+                    else
+                    {
+                        builder.Append(value);
+                    }
+                }
+                break;
+            default:
+                var inner = child.InnerText;
+                if (!string.IsNullOrEmpty(inner))
+                {
+                    builder.Append(inner);
+                }
+                break;
+        }
+    }
+
+    if (builder.Length > 0)
+    {
+        return builder.ToString();
+    }
+
+    return run.InnerText ?? string.Empty;
+}
+
+private static JsonParagraph ParseParagraph(Wp.Paragraph para, int elementId, MainDocumentPart mainPart, string structureKey)
+{
+    var jsonPara = new JsonParagraph { ID = elementId, StructureKey = structureKey };
     var pPr = para.ParagraphProperties;
     if (pPr != null)
     {
@@ -810,11 +923,15 @@ private static JsonParagraph ParseParagraph(Wp.Paragraph para, int elementId, Ma
             }
             jsonPara.Content.Add(new JsonCheckbox { IsChecked = checkedState?.Val?.Value ?? false, Content = labelText });
         }
-        // ***** THIS IS THE FIX *****
-        // Revert to InnerText to capture all text and symbols, not just <w:t> elements.
-        else if (!string.IsNullOrEmpty(run.InnerText))
+        else
         {
-            var jsonRun = new JsonRun { Text = run.InnerText }; // Using InnerText from v1
+            string runText = ExtractRunTextWithBreaks(run);
+            if (string.IsNullOrEmpty(runText) && !run.Descendants<Wp.Break>().Any() && !run.Descendants<Wp.CarriageReturn>().Any())
+            {
+                continue;
+            }
+
+            var jsonRun = new JsonRun { Text = runText };
             var rPr = run.RunProperties;
             if (rPr != null)
             {
@@ -833,15 +950,15 @@ private static JsonParagraph ParseParagraph(Wp.Paragraph para, int elementId, Ma
     }
     if (para.Descendants<Wp.Drawing>().Any())
     {
-        var images = ParseImages(para, elementId, mainPart);
+        var images = ParseImages(para, elementId, mainPart, structureKey);
         if (images != null) { jsonPara.Content.AddRange(images); }
     }
     return jsonPara;
 }
 
-    private static JsonTable ParseTable(Wp.Table table, int elementId, MainDocumentPart mainPart)
+    private static JsonTable ParseTable(Wp.Table table, int elementId, MainDocumentPart mainPart, string structureKey)
     {
-        var jsonTable = new JsonTable { ID = elementId };
+        var jsonTable = new JsonTable { ID = elementId, StructureKey = structureKey };
         var tblProps = table.GetFirstChild<Wp.TableProperties>();
         if (tblProps != null)
         {
@@ -858,9 +975,11 @@ private static JsonParagraph ParseParagraph(Wp.Paragraph para, int elementId, Ma
             jsonTable.Borders["Direction"] = tblProps.GetFirstChild<Wp.BiDiVisual>() != null ? "RTL" : "LTR";
         }
         var tableData = new List<JsonTableRow>();
+        int rowIndex = 0;
         foreach (var row in table.Elements<Wp.TableRow>())
         {
             var jsonRow = new JsonTableRow();
+            int cellIndex = 0;
             foreach (var cell in row.Elements<Wp.TableCell>())
             {
                 var jsonCell = new JsonTableCell();
@@ -877,10 +996,14 @@ private static JsonParagraph ParseParagraph(Wp.Paragraph para, int elementId, Ma
                     jsonCell.Direction = isDocumentRtl ? "RTL" : "LTR";
                     jsonCell.Alignment = isDocumentRtl ? "right" : "left";
                 }
-                
+
+                int paragraphIndex = 0;
                 foreach (var para in cell.Elements<Wp.Paragraph>())
                 {
-                    var parsedPara = ParseParagraph(para, 0, mainPart);
+                    string paragraphKey = string.IsNullOrEmpty(structureKey)
+                        ? null
+                        : $"{structureKey}.r{rowIndex}c{cellIndex}p{paragraphIndex}";
+                    var parsedPara = ParseParagraph(para, 0, mainPart, paragraphKey);
                     if (parsedPara?.Content != null)
                     {
                         var runs = parsedPara.Content.OfType<JsonRun>();
@@ -888,6 +1011,7 @@ private static JsonParagraph ParseParagraph(Wp.Paragraph para, int elementId, Ma
                         var checkboxes = parsedPara.Content.OfType<JsonCheckbox>();
                         if (checkboxes != null) jsonCell.Checkboxes.AddRange(checkboxes);
                     }
+                    paragraphIndex++;
                 }
                 jsonCell.Content = string.Join("", jsonCell.FormattedRuns.Where(r => r != null).Select(r => r.Text ?? ""));
                 var cellProps = cell.TableCellProperties;
@@ -908,8 +1032,10 @@ private static JsonParagraph ParseParagraph(Wp.Paragraph para, int elementId, Ma
                     jsonCell.Borders["Background"] = cellProps.Shading?.Fill ?? "inherit";
                 }
                 jsonRow.Cells.Add(jsonCell);
+                cellIndex++;
             }
             tableData.Add(jsonRow);
+            rowIndex++;
         }
         jsonTable.Content = tableData;
         CalculateRowSpans(jsonTable);
@@ -984,12 +1110,13 @@ private static JsonParagraph ParseParagraph(Wp.Paragraph para, int elementId, Ma
         }
     }
 
-    private static List<JsonImage> ParseImages(OpenXmlElement element, int elementId, MainDocumentPart mainPart)
+    private static List<JsonImage> ParseImages(OpenXmlElement element, int elementId, MainDocumentPart mainPart, string structureKey)
     {
         var images = new List<JsonImage>();
         try
         {
             var drawings = element.Descendants<Wp.Drawing>();
+            int imageIndex = 0;
             foreach (var drawing in drawings)
             {
                 var blip = drawing.Descendants<A.Blip>().FirstOrDefault();
@@ -1003,10 +1130,12 @@ private static JsonParagraph ParseParagraph(Wp.Paragraph para, int elementId, Ma
                             var imageBytes = new byte[stream.Length];
                             stream.Read(imageBytes, 0, imageBytes.Length);
                             string base64String = Convert.ToBase64String(imageBytes);
-                            images.Add(new JsonImage { ID = elementId, Content = base64String });
+                            string imageKey = string.IsNullOrEmpty(structureKey) ? null : $"{structureKey}:img{imageIndex}";
+                            images.Add(new JsonImage { ID = elementId, Content = base64String, StructureKey = imageKey });
                         }
                     }
                 }
+                imageIndex++;
             }
         }
         catch

--- a/docfront.cshtml
+++ b/docfront.cshtml
@@ -929,34 +929,41 @@
             return;
         }
         docContainer.css('direction', documentData.json.Direction || 'ltr');
-        const renderRun = (run, elementId, runIndex) => {
-    if (!run || typeof run.Text === 'undefined') return '';
-    let runStyle = '';
-    const f = run.Formatting || {};
-    const fv = run.FormattingValues || {};
-    if (f.Bold) runStyle += 'font-weight: bold;';
-    if (f.Italic) runStyle += 'font-style: italic;';
-    if (f.Underline) runStyle += 'text-decoration: underline;';
-    if (fv.ColorValue) runStyle += `color: #${fv.ColorValue};`;
-    if (fv.FontSize) runStyle += `font-size: ${parseInt(fv.FontSize) / 2}pt;`;
-    if (fv.FontFamily) runStyle += `font-family: "${fv.FontFamily}";`;
-    if (fv.ShadingValue) runStyle += `background-color: #${fv.ShadingValue};`;
+        const formatRunText = (text) => {
+            if (typeof text !== 'string') return '';
+            const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+            return normalized
+                .split('\n')
+                .map(line => escapeHtml(line).replace(/\t/g, '&emsp;').replace(/ /g, '&nbsp;'))
+                .join('<br>');
+        };
 
-    if (run.Text.includes('☐') || run.Text.includes('☑')) {
-        const textParts = run.Text.split(/(☐|☑)/).filter(part => part);
-        return textParts.map(part => {
-            if (part === '☐' || part === '☑') {
-                const isChecked = part === '☑';
-                return `<input type="checkbox" class="editable-checkbox-symbol" ${isChecked ? 'checked' : ''}>`;
-            } else {
-                // Apply escaping to the text part
-                return `<span style="${runStyle}">${escapeHtml(part).replace(/ /g, '&nbsp;')}</span>`;
+        const renderRun = (run, elementId, runIndex) => {
+            if (!run || typeof run.Text === 'undefined') return '';
+            let runStyle = '';
+            const f = run.Formatting || {};
+            const fv = run.FormattingValues || {};
+            if (f.Bold) runStyle += 'font-weight: bold;';
+            if (f.Italic) runStyle += 'font-style: italic;';
+            if (f.Underline) runStyle += 'text-decoration: underline;';
+            if (fv.ColorValue) runStyle += `color: #${fv.ColorValue};`;
+            if (fv.FontSize) runStyle += `font-size: ${parseInt(fv.FontSize) / 2}pt;`;
+            if (fv.FontFamily) runStyle += `font-family: "${fv.FontFamily}";`;
+            if (fv.ShadingValue) runStyle += `background-color: #${fv.ShadingValue};`;
+
+            if (run.Text.includes('☐') || run.Text.includes('☑')) {
+                const textParts = run.Text.split(/(☐|☑)/).filter(part => part);
+                return textParts.map(part => {
+                    if (part === '☐' || part === '☑') {
+                        const isChecked = part === '☑';
+                        return `<input type="checkbox" class="editable-checkbox-symbol" ${isChecked ? 'checked' : ''}>`;
+                    } else {
+                        return `<span style="${runStyle}">${formatRunText(part)}</span>`;
+                    }
+                }).join('');
             }
-        }).join('');
-    }
-    // Apply escaping to the whole text
-    return `<span style="${runStyle}">${escapeHtml(run.Text || '').replace(/ /g, '&nbsp;')}</span>`;
-};
+            return `<span style="${runStyle}">${formatRunText(run.Text || '')}</span>`;
+        };
 function escapeHtml(text) {
     if (typeof text !== 'string') return '';
     return text
@@ -1039,11 +1046,15 @@ function escapeHtml(text) {
                 } else if (this.nodeType === Node.ELEMENT_NODE) {
                     if (this.tagName.toLowerCase() === 'input' && this.type.toLowerCase() === 'checkbox') {
                         newTextContent += this.checked ? '☑' : '☐';
+                    } else if (this.tagName.toLowerCase() === 'br') {
+                        newTextContent += '\n';
                     } else {
                         newTextContent += $(this).text();
                     }
                 }
             });
+
+            newTextContent = newTextContent.replace(/\u00A0/g, ' ').replace(/\u2003/g, '\t');
 
             if (targetArray.length > 0) {
                 targetArray[0].Text = newTextContent;


### PR DESCRIPTION
## Summary
- attach deterministic StructureKey paths to paragraphs and tables so JSON updates map back to the same DOCX elements
- preserve line breaks, tabs, and checkbox glyphs when parsing runs and render them consistently in the HTML front-end
- document the new structure mapping and line fidelity expectations in the bilingual README
- propagate structure keys when parsing table cell paragraphs to satisfy the updated ParseParagraph signature

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e371ab2d0483339a5d55ded82b2c90