### PR TITLE
Preserve multiline input when editing document cells

### DIFF
--- a/docapi.cshtml
+++ b/docapi.cshtml
@@ -831,7 +831,27 @@ private static List<List<JsonRun>> BuildParagraphPayloadFromRuns(List<JsonRun> r
                 continue;
             }
 
-            current.Add(CloneRunWithText(run, run.Text));
+            var runText = run.Text ?? string.Empty;
+            var normalizedText = runText.Replace("\r\n", "\n").Replace("\r", "\n");
+
+            if (normalizedText.Contains("\n"))
+            {
+                var segments = normalizedText.Split('\n');
+                for (int i = 0; i < segments.Length; i++)
+                {
+                    current.Add(CloneRunWithText(run, segments[i]));
+
+                    if (i < segments.Length - 1)
+                    {
+                        payloads.Add(current);
+                        current = new List<JsonRun>();
+                    }
+                }
+
+                continue;
+            }
+
+            current.Add(CloneRunWithText(run, runText));
         }
     }
 

--- a/docfront.cshtml
+++ b/docfront.cshtml
@@ -801,6 +801,7 @@
     var currentFullCode = '';
     var currentDocumentName = '';
     const t = @Html.Raw(Newtonsoft.Json.JsonConvert.SerializeObject(t));
+    const BLOCK_LEVEL_TAGS = ['DIV', 'P', 'LI', 'UL', 'OL', 'SECTION', 'ARTICLE', 'TABLE', 'THEAD', 'TBODY', 'TFOOT', 'TR', 'TD', 'TH', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6'];
 
     function getCookie(c) { let n = c + "="; let d = decodeURIComponent(document.cookie); let a = d.split(';'); for (let i = 0; i < a.length; i++) { let f = a[i].trim(); if (f.indexOf(n) == 0) return f.substring(n.length, f.length); } return ""; }
     function uuid() { return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => { const r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8); return v.toString(16); }); }
@@ -872,6 +873,34 @@
             } else { v2Json.Elements.push(el); }
         });
         return { success: true, json: v2Json };
+    }
+
+    function extractTextPreservingLineBreaks(node, isRoot = true) {
+        if (!node) return '';
+        if (node.nodeType === Node.TEXT_NODE) {
+            return node.textContent;
+        }
+        if (node.nodeType !== Node.ELEMENT_NODE) {
+            return '';
+        }
+
+        const tagName = node.tagName ? node.tagName.toUpperCase() : '';
+        if (tagName === 'BR') {
+            return '\n';
+        }
+        if (tagName === 'INPUT' && node.type && node.type.toLowerCase() === 'checkbox') {
+            return node.checked ? '☑' : '☐';
+        }
+
+        let text = '';
+        for (let i = 0; i < node.childNodes.length; i++) {
+            text += extractTextPreservingLineBreaks(node.childNodes[i], false);
+        }
+
+        if (!isRoot && tagName && BLOCK_LEVEL_TAGS.includes(tagName) && text && !text.endsWith('\n')) {
+            text += '\n';
+        }
+        return text;
     }
 
     function preprocessTemplateData(json) {
@@ -1039,22 +1068,9 @@ function escapeHtml(text) {
                 return;
             }
 
-            let newTextContent = "";
-            domElement.contents().each(function() {
-                if (this.nodeType === Node.TEXT_NODE) {
-                    newTextContent += this.textContent;
-                } else if (this.nodeType === Node.ELEMENT_NODE) {
-                    if (this.tagName.toLowerCase() === 'input' && this.type.toLowerCase() === 'checkbox') {
-                        newTextContent += this.checked ? '☑' : '☐';
-                    } else if (this.tagName.toLowerCase() === 'br') {
-                        newTextContent += '\n';
-                    } else {
-                        newTextContent += $(this).text();
-                    }
-                }
-            });
-
-            newTextContent = newTextContent.replace(/\u00A0/g, ' ').replace(/\u2003/g, '\t');
+            let newTextContent = extractTextPreservingLineBreaks(domElement[0]);
+            newTextContent = newTextContent.replace(/\r/g, '').replace(/\u00A0/g, ' ').replace(/\u2003/g, '\t');
+            newTextContent = newTextContent.replace(/\n+$/g, '');
 
             if (targetArray.length > 0) {
                 targetArray[0].Text = newTextContent;


### PR DESCRIPTION
## Summary
- EN: Read block-level nodes and `<br>` elements from editable cells so saved JSON retains in-cell newlines.
- AR: قراءة العقد ذات المستوى الكتلي وعناصر `<br>` من الخلايا القابلة للتحرير لضمان احتفاظ JSON المحفوظ بفواصل الأسطر داخل الخلية.

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3958300f48333ad52f88c7df80f39