### PR TITLE
Fix RTL paragraph handling during document generation

### DIFF
--- a/docapi.cshtml
+++ b/docapi.cshtml
@@ -493,13 +493,20 @@ private static void InjectTextToParagraphSafe(Wp.Paragraph para, JsonParagraph j
             .Select(r => r.RunProperties != null ? (Wp.RunProperties)r.RunProperties.CloneNode(true) : null)
             .ToList();
 
-        if (jsonPara.Formatting.TryGetValue("Direction", out object dirValue) && dirValue?.ToString() == "RTL")
+        if (jsonPara.Formatting != null && jsonPara.Formatting.TryGetValue("Direction", out object dirValue))
         {
-            if (pPr.BiDi == null) pPr.Append(new Wp.BiDi());
-        }
-        else
-        {
-            pPr.BiDi?.Remove();
+            var direction = dirValue?.ToString();
+            if (!string.IsNullOrWhiteSpace(direction))
+            {
+                if (direction.Equals("RTL", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (pPr.BiDi == null) pPr.Append(new Wp.BiDi());
+                }
+                else if (!direction.Equals("inherit", StringComparison.OrdinalIgnoreCase))
+                {
+                    pPr.BiDi?.Remove();
+                }
+            }
         }
 
         if (jsonPara.Formatting.TryGetValue("Alignment", out object alignValue))


### PR DESCRIPTION
## Summary
- preserve existing paragraph bidi settings when JSON payload omits a direction value
- ignore neutral direction values to avoid unintentionally forcing LTR content

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3ac7c8d048333b0e35396666c3da3